### PR TITLE
Fix quick pull down rtl values

### DIFF
--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -196,9 +196,9 @@
     </string-array>
 
     <string-array name="status_bar_quick_pull_down_values_rtl" translatable="false">
+        <item>0</item>
         <item>2</item>
         <item>1</item>
-        <item>0</item>
         <item>3</item>
     </string-array>
 


### PR DESCRIPTION
These should match `status_bar_quick_pull_down_entries_rtl`.