### PR TITLE
quicksettings: allow 6 columns in portrait mode over 5

### DIFF
--- a/res/xml/qs_layout_settings.xml
+++ b/res/xml/qs_layout_settings.xml
@@ -23,7 +23,7 @@
     <org.evolution.settings.preferences.SystemSettingSeekBarPreference
         android:key="qs_layout_columns"
         android:title="@string/quick_settings_columns_portrait_title"
-        android:max="5"
+        android:max="6"
         settings:min="2"
         settings:interval="1"
         android:defaultValue="2" />


### PR DESCRIPTION
In Android 11 (stock + many OEM roms), the maximum amount of portrait columns was 6, so this change makes the Android 11 QS Style a bit more authentic.

Tested on OnePlus 12 (Unofficial)

