### PR TITLE
Update BootAnimation.java

### DIFF
--- a/src/org/evolution/settings/fragments/themes/BootAnimation.java
+++ b/src/org/evolution/settings/fragments/themes/BootAnimation.java
@@ -142,6 +142,8 @@ public class BootAnimation extends SettingsPreferenceFragment implements OnPrefe
                 }
             }
             inputStream.close();
+            // Set permissions to 644 (rw-r--r--) so 'graphics' user can read it
+            customBootAnimation.setReadable(true, false);
             // Update system property to use custom boot animation
             SystemProperties.set(BOOTANIMATION_STYLE_KEY, "13"); // Custom option value
             updateBootAnimationPreview();


### PR DESCRIPTION
BootAnimation: Fix permission issue for custom boot animation

Previously, when a custom boot animation zip was copied to  /data/misc/bootanim/bootanimation.zip, it was created with restrictive  permissions (typically 0600), readable only by the 'system' user.

Since the bootanim service often runs as the 'graphics' user, it was  unable to read the file, causing the animation to fail and fallback  to the default Android logo.

This change explicitly sets the file permissions to world-readable (0644)  after copying, ensuring the bootanim service can access and play the  custom animation.