### PR TITLE
Evolver: Pulse: Add missing particle renderer option

### DIFF
--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -696,6 +696,7 @@
         <item>@string/pulse_renderer_minimal_wave</item>
         <item>@string/pulse_renderer_sparkle</item>
         <item>@string/pulse_renderer_matrix</item>
+        <item>@string/pulse_renderer_particle</item>
         <item>@string/pulse_renderer_waveform</item>
     </string-array>
 


### PR DESCRIPTION
Ideally squash this with the waveform renderer commit
(apologies for missing this and breaking the setting)